### PR TITLE
Implementing 'Block' Action and Refining Saves

### DIFF
--- a/packages/core/src/action.ts
+++ b/packages/core/src/action.ts
@@ -21,8 +21,9 @@ type ValidAction =
 	| ['vibrate', [...number[]]]
 	| ['next', []]
 	| ['text', [...string[]]]
-	| ['exit']
+	| ['exit', ["block" | undefined]]
 	| ['preload', [string]]
+	| ['block', [string]]
 	| ValidAction[];
 
 type Story = Record<string, ValidAction[]>;
@@ -108,12 +109,16 @@ type ActionProxyProvider<Characters extends Record<string, Character>> = {
 			...choices: ([Unwrappable, ValidAction[]] | [Unwrappable, ValidAction[], () => boolean])[]
 		): ValidAction;
 	};
+
 	clear: (keep?: Set<keyof DefaultActionProxyProvider>, keepCharacters?: Set<string>) => ValidAction;
+
 	condition: <T extends string | true | false>(
 		condition: () => T,
 		variants: Record<T extends true ? 'true' : T extends false ? 'false' : T, ValidAction[]>,
 	) => ValidAction;
-	exit: () => ValidAction;
+
+	exit: (type: "block" | undefined) => ValidAction;
+
 	dialog: {
 		<C extends keyof Characters>(
 			person: C,
@@ -123,10 +128,13 @@ type ActionProxyProvider<Characters extends Record<string, Character>> = {
 		(person: undefined, content: Unwrappable, emotion?: undefined): ValidAction;
 		(person: string, content: Unwrappable, emotion?: undefined): ValidAction;
 	};
+
 	end: () => ValidAction;
+
 	showBackground: <T extends string | BackgroundImage>(background: T extends string ? T : T extends Record<PropertyKey, unknown> ? NonEmptyRecord<T> : never) => ValidAction;
 
 	playMusic: (audio: string) => ValidAction;
+
 	stopMusic: (audio: string) => ValidAction;
 
 	jump: (scene: string) => ValidAction;
@@ -139,13 +147,13 @@ type ActionProxyProvider<Characters extends Record<string, Character>> = {
 			style?: string,
 		): ValidAction;
 	};
-	hideCharacter: {
-		<C extends keyof Characters>(character: C, className?: string, style?: string, duration?: number): ValidAction;
-	};
-	animateCharacter: {
-		<C extends keyof Characters>(character: C, timeout: number, ...classes: string[]): ValidAction;
-	};
+
+	hideCharacter: (character: keyof Characters, className?: string, style?: string, duration?: number) => ValidAction;
+
+	animateCharacter: (character: keyof Characters, timeout: number, ...classes: string[]) => ValidAction;
+
 	wait: (time: FunctionableValue<number>) => ValidAction;
+
 	function: (fn: (restoring: boolean, goingBack: boolean) => Thenable<void>) => ValidAction;
 
 	input: (
@@ -163,6 +171,8 @@ type ActionProxyProvider<Characters extends Record<string, Character>> = {
 	text: (...text: Unwrappable[]) => ValidAction;
 
 	preload: (source: string) => ValidAction;
+
+	block: (scene: string) => ValidAction;
 };
 
 type DefaultActionProxyProvider = ActionProxyProvider<Record<string, Character>>;

--- a/packages/core/src/action.ts
+++ b/packages/core/src/action.ts
@@ -21,7 +21,7 @@ type ValidAction =
 	| ['vibrate', [...number[]]]
 	| ['next', []]
 	| ['text', [...string[]]]
-	| ['exit', ["block" | undefined]]
+	| ['exit', []]
 	| ['preload', [string]]
 	| ['block', [string]]
 	| ValidAction[];
@@ -117,7 +117,7 @@ type ActionProxyProvider<Characters extends Record<string, Character>> = {
 		variants: Record<T extends true ? 'true' : T extends false ? 'false' : T, ValidAction[]>,
 	) => ValidAction;
 
-	exit: (type: "block" | undefined) => ValidAction;
+	exit: () => ValidAction;
 
 	dialog: {
 		<C extends keyof Characters>(

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -2,8 +2,12 @@ import type { TypewriterSpeed } from './types';
 
 const SKIPPED_DURING_RESTORE = new Set(['dialog', 'choice', 'input', 'vibrate', 'text'] as const);
 
+const BLOCK_EXIT_STATEMENTS = new Set(["choice:exit", "condition:exit", "block:exit"]);
+
+const BLOCK_STATEMENTS = new Set(['choice', 'condition', 'block']);
+
 const EMPTY_SET = new Set<any>();
 
 const DEFAULT_TYPEWRITER_SPEED: TypewriterSpeed = 'Medium';
 
-export { SKIPPED_DURING_RESTORE, EMPTY_SET, DEFAULT_TYPEWRITER_SPEED };
+export { SKIPPED_DURING_RESTORE, EMPTY_SET, DEFAULT_TYPEWRITER_SPEED, BLOCK_EXIT_STATEMENTS, BLOCK_STATEMENTS };

--- a/packages/core/src/novely.ts
+++ b/packages/core/src/novely.ts
@@ -27,7 +27,7 @@ import {
 	findLastIndex,
 	preloadImagesBlocking,
 	createDeferredPromise,
-	findLastPathItemBeforeBlockItemIndex,
+	findLastPathItemBeforeItemOfType,
 	isBlockStatement,
 	isBlockExitStatement
 } from './utils';
@@ -518,13 +518,12 @@ const novely = <
 					let startIndex = 0;
 
 					if (ignoreNested) {
-						const prev = path[findLastPathItemBeforeBlockItemIndex(path)] as [
-							null,
-							number
-						];
+						const prev = findLastPathItemBeforeItemOfType(path.slice(0, index), 'block');
 
-						startIndex = prev[1];
-						ignoreNested = false;
+						if (prev) {
+							startIndex = prev[1];
+							ignoreNested = false;
+						}
 					}
 
 					/**
@@ -1008,16 +1007,9 @@ const novely = <
 				/**
 				 * Exit from the path
 				 */
-				path.push([`${name}:exit`] as unknown as PathItem);
+				path.push([`${name}:exit`]);
 
-				const index = findLastIndex(path.slice(0, i + 1), ([_name, value], next) => isNull(_name) && isNumber(value) && next != null && next[0] === name);
-				/**
-				 * Actual check is made in the line above
-				 */
-				const prev = path[index] as [
-					null,
-					number
-				];
+				const prev = findLastPathItemBeforeItemOfType(path.slice(0, i + 1), name);
 
 				/**
 				 * When possible also go to the next action (or exit from one layer above)

--- a/packages/core/src/novely.ts
+++ b/packages/core/src/novely.ts
@@ -481,7 +481,7 @@ const novely = <
 		 */
 		let precurrent: any;
 		/**
-		 * Should we ignore `[null, int]` actions from `0` to `int`
+		 * Should we ignore some actions
 		 */
 		let ignoreNested = false;
 
@@ -974,11 +974,10 @@ const novely = <
 		exit([type]) {
 			const path = stack.value[0];
 
+			/**
+			 * @todo: This is nice way to preserve everything, maybe use it everywhere?
+			 */
 			if (type === 'block') {
-				/**
-				 * Original `exit` removes nested condition and choice paths, so during restore it never re-runs
-				 * But `block` must be also called during restore. So, we must not add redundant `block:exit`
-				 */
 				if (restoring) return;
 
 				/**
@@ -1013,7 +1012,11 @@ const novely = <
 			for (let i = path.length - 1; i > 0; i--) {
 				const name = path[i][0];
 
-				if (name !== 'choice' && name !== 'condition') continue;
+				if (name !== 'choice' && name !== 'condition' && name !== 'block') continue;
+
+				if (name === 'block') {
+					console.warn('You should use `action.exit("block")` at the end of the block')
+				}
 
 				exited = true;
 				stack.value[0] = path.slice(0, i);

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -6,7 +6,9 @@ type Thenable<T> = T | Promise<T>;
 type PathItem =
 	| [null, number | string]
 	| ['choice' & Record<never, never>, number]
+	| ['choice:exit']
 	| ['condition' & Record<never, never>, string]
+	| ['condition:exit']
 	| ['exit' & Record<never, never>]
 	| ['block', string]
 	| ['block:exit'];

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -7,7 +7,10 @@ type PathItem =
 	| [null, number | string]
 	| ['choice' & Record<never, never>, number]
 	| ['condition' & Record<never, never>, string]
-	| ['exit' & Record<never, never>];
+	| ['exit' & Record<never, never>]
+	| ['block', string]
+	| ['block:exit'];
+
 type Path = PathItem[];
 
 type State = Record<string, any>;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -67,6 +67,7 @@ type NonEmptyRecord<T extends Record<PropertyKey, unknown>> = keyof T extends ne
 
 export type {
 	Thenable,
+	PathItem,
 	Path,
 	Save,
 	State,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -5,11 +5,11 @@ type Thenable<T> = T | Promise<T>;
 
 type PathItem =
 	| [null, number | string]
-	| ['choice' & Record<never, never>, number]
+	| ['choice', number]
 	| ['choice:exit']
-	| ['condition' & Record<never, never>, string]
+	| ['condition', string]
 	| ['condition:exit']
-	| ['exit' & Record<never, never>]
+	| ['exit']
 	| ['block', string]
 	| ['block:exit'];
 

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -1,6 +1,6 @@
 import type { ActionProxyProvider, CustomHandler } from './action';
 import type { Character } from './character';
-import type { Thenable } from './types';
+import type { Thenable, Path } from './types';
 
 type MatchActionMap = {
 	[Key in keyof ActionProxyProvider<Record<string, Character>>]: (
@@ -116,9 +116,9 @@ const vibrate = (pattern: VibratePattern) => {
 	} catch {}
 };
 
-const findLastIndex = <T>(array: T[], fn: (item: T) => boolean) => {
-	for (let i = array.length - 1; i > 0; i--) {
-		if (fn(array[i])) {
+const findLastIndex = <T>(array: T[], fn: (item: T, next?: T) => boolean) => {
+	for (let i = array.length - 1; i >= 0; i--) {
+		if (fn(array[i], array[i + 1])) {
 			return i;
 		}
 	}
@@ -157,6 +157,10 @@ const createDeferredPromise = <T = void>() => {
 	return { resolve, reject, promise }
 }
 
+const findLastPathItemBeforeBlockItemIndex = (path: Path) => {
+	return findLastIndex(path, ([name, value], next) => isNull(name) && isNumber(value) && next != null && next[0] === 'block');
+}
+
 export {
 	matchAction,
 	isNumber,
@@ -173,5 +177,6 @@ export {
 	vibrate,
 	findLastIndex,
 	preloadImagesBlocking,
-	createDeferredPromise
+	createDeferredPromise,
+	findLastPathItemBeforeBlockItemIndex
 };

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -1,6 +1,7 @@
 import type { ActionProxyProvider, CustomHandler } from './action';
 import type { Character } from './character';
 import type { Thenable, Path } from './types';
+import { BLOCK_STATEMENTS, BLOCK_EXIT_STATEMENTS } from './constants';
 
 type MatchActionMap = {
 	[Key in keyof ActionProxyProvider<Record<string, Character>>]: (
@@ -161,6 +162,14 @@ const findLastPathItemBeforeBlockItemIndex = (path: Path) => {
 	return findLastIndex(path, ([name, value], next) => isNull(name) && isNumber(value) && next != null && next[0] === 'block');
 }
 
+const isBlockStatement = (statement: unknown): statement is 'choice' | 'condition' | 'block' => {
+	return BLOCK_STATEMENTS.has(statement as any);
+}
+
+const isBlockExitStatement = (statement: unknown): statement is "choice:exit" | "condition:exit" | "block:exit" => {
+	return BLOCK_EXIT_STATEMENTS.has(statement as any);
+}
+
 export {
 	matchAction,
 	isNumber,
@@ -178,5 +187,7 @@ export {
 	findLastIndex,
 	preloadImagesBlocking,
 	createDeferredPromise,
-	findLastPathItemBeforeBlockItemIndex
+	findLastPathItemBeforeBlockItemIndex,
+	isBlockStatement,
+	isBlockExitStatement
 };

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -1,6 +1,6 @@
 import type { ActionProxyProvider, CustomHandler } from './action';
 import type { Character } from './character';
-import type { Thenable, Path } from './types';
+import type { Thenable, Path, PathItem } from './types';
 import { BLOCK_STATEMENTS, BLOCK_EXIT_STATEMENTS } from './constants';
 
 type MatchActionMap = {
@@ -158,8 +158,15 @@ const createDeferredPromise = <T = void>() => {
 	return { resolve, reject, promise }
 }
 
-const findLastPathItemBeforeBlockItemIndex = (path: Path) => {
-	return findLastIndex(path, ([name, value], next) => isNull(name) && isNumber(value) && next != null && next[0] === 'block');
+const findLastPathItemBeforeItemOfType = (path: Path, name: PathItem[0]) => {
+	const index = findLastIndex(path, ([_name, _value], next) => {
+		return isNull(_name) && isNumber(_value) && next != null && next[0] === name;
+	});
+
+	return path[index] as undefined | [
+		null,
+		number
+	];
 }
 
 const isBlockStatement = (statement: unknown): statement is 'choice' | 'condition' | 'block' => {
@@ -187,7 +194,7 @@ export {
 	findLastIndex,
 	preloadImagesBlocking,
 	createDeferredPromise,
-	findLastPathItemBeforeBlockItemIndex,
+	findLastPathItemBeforeItemOfType,
 	isBlockStatement,
 	isBlockExitStatement
 };

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -1,7 +1,7 @@
-import type { ActionProxyProvider, CustomHandler } from './action';
+import type { ActionProxyProvider, CustomHandler, ValidAction } from './action';
 import type { Character } from './character';
 import type { Thenable, Path, PathItem } from './types';
-import { BLOCK_STATEMENTS, BLOCK_EXIT_STATEMENTS } from './constants';
+import { BLOCK_STATEMENTS, BLOCK_EXIT_STATEMENTS, SKIPPED_DURING_RESTORE } from './constants';
 
 type MatchActionMap = {
 	[Key in keyof ActionProxyProvider<Record<string, Character>>]: (
@@ -177,6 +177,16 @@ const isBlockExitStatement = (statement: unknown): statement is "choice:exit" | 
 	return BLOCK_EXIT_STATEMENTS.has(statement as any);
 }
 
+const isSkippedDurigRestore = (item: unknown): item is "vibrate" | "dialog" | "input" | "choice" | "text" => {
+	return SKIPPED_DURING_RESTORE.has(item as any);
+}
+
+const noop = () => {}
+
+const isAction = (element: unknown): element is [keyof MatchActionMapComplete, ...Parameters<MatchActionMapComplete[keyof MatchActionMapComplete]>] => {
+	return Array.isArray(element) && isString(element[0]);
+}
+
 export {
 	matchAction,
 	isNumber,
@@ -196,5 +206,8 @@ export {
 	createDeferredPromise,
 	findLastPathItemBeforeItemOfType,
 	isBlockStatement,
-	isBlockExitStatement
+	isBlockExitStatement,
+	isSkippedDurigRestore,
+	noop,
+	isAction
 };

--- a/packages/preview/src/main.tsx
+++ b/packages/preview/src/main.tsx
@@ -58,7 +58,7 @@ const engine = novely({
 	}),
 
 	state: {
-		age: 15,
+		age: 0,
 	},
 
 	data: {
@@ -73,7 +73,9 @@ const engine = novely({
 
 	initialScreen: 'mainmenu',
 
-	preloadAssets: 'lazy'
+	preloadAssets: 'lazy',
+
+	askBeforeExit: false
 });
 
 const { action, state, data, t, unwrap } = engine;
@@ -171,9 +173,10 @@ engine.withStory({
 					en: 'You will be shown a full-screen ad',
 					ru: 'Вам будет показана полноэкранная реклама',
 				})),
+				action.showBackground('green'),
 				action.exit('block')
 			]
-		})
+		}),
 	],
 	start: [
 		action.custom(hide()),

--- a/packages/preview/src/main.tsx
+++ b/packages/preview/src/main.tsx
@@ -164,6 +164,17 @@ registerMainmenuItem((goto) => ({
 }));
 
 engine.withStory({
+	'block:adv': [
+		action.condition(() => true, {
+			true: [
+				action.text(t({
+					en: 'You will be shown a full-screen ad',
+					ru: 'Вам будет показана полноэкранная реклама',
+				})),
+				action.exit('block')
+			]
+		})
+	],
 	start: [
 		action.custom(hide()),
 		action.preload(outdoor),
@@ -173,12 +184,7 @@ engine.withStory({
 		})),
 		action.custom(particles(snow)),
 		action.showBackground(outdoor),
-		action.showBackground({
-			'all': 'red',
-			'(max-width: 2000px)': 'blue',
-			'(max-width: 1000px)': '#f67288',
-			'(max-width: 800px)': 'yellow',
-		}),
+		action.block('block:adv'),
 		action.showCharacter('Lily', 'ok'),
 		action.animateCharacter('Lily', 1000, 'animate__animated', 'animate__pulse'),
 		action.dialog(

--- a/packages/preview/src/main.tsx
+++ b/packages/preview/src/main.tsx
@@ -173,8 +173,6 @@ engine.withStory({
 					en: 'You will be shown a full-screen ad',
 					ru: 'Вам будет показана полноэкранная реклама',
 				})),
-				action.showBackground('green'),
-				action.exit('block')
 			]
 		}),
 	],


### PR DESCRIPTION
- Added `block` action. Now it is possible to insert some repeating block to the story. Monogatari has [something similar](https://developers.monogatari.io/documentation/script-actions/placeholder). Hovewer, our `block` cannot be dynamic or have arguments.
- Changed `choice` and `condition` saves. Previously, they were ignored during restore step. Now, it's not.
- Added reference check for `custom` actions. In case it is the same function reference that does not has it it will be faster then comparing functions as strings.