### PR TITLE
Dynamic Character Improvements

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@novely/core",
 	"description": "Novely - powerful visual novel engine for creating interactive stories and games with branching narratives and rich multimedia content",
-	"version": "0.48.0",
+	"version": "0.49.0-experemental.0",
 	"type": "module",
 	"sideEffects": false,
 	"publishConfig": {

--- a/packages/dynamic-character/README.md
+++ b/packages/dynamic-character/README.md
@@ -14,75 +14,77 @@ import '@novely/dynamic-character/dist/index.css';
 ```
 
 ```ts
-import Ryan_zombie from './assets/Ryan-zombie-body.png';
-import Ryan_zombie_bottoms__shorts from './assets/Ryan-zombie-bottoms--shorts.png'
-import Ryan_zombie_bottoms__jeans from './assets/Ryan-zombie-bottoms--jeans.png'
-import Ryan_zombie_tops__pink_tshirt from './assets/Ryan-zombie-tops--pink-t-shirt.png';
-import Ryan_zombie_tops__white_tshirt from './assets/Ryan-zombie-tops--white-t-shirt.png';
+import { novely, asset, EN } from '@novely/core';
 
-import Ryan_default from './assets/Ryan-default-body.png';
-import Ryan_default_bottoms__shorts from './assets/Ryan-default-bottoms--shorts.png'
-import Ryan_default_bottoms__jeans from './assets/Ryan-default-bottoms--jeans.png'
-import Ryan_default_tops__pink_tshirt from './assets/Ryan-default-tops--pink-t-shirt.png';
-import Ryan_default_tops__white_tshirt from './assets/Ryan-default-tops--white-t-shirt.png';
+import You_female from './assets/You-female-body.png';
+import You_female_bottoms__shorts from './assets/You-female-bottoms--shorts.png'
+import You_female_bottoms__jeans from './assets/You-female-bottoms--jeans.png'
+import You_female_tops__pink_tshirt from './assets/You-female-tops--pink-t-shirt.png';
+import You_female_tops__white_tshirt from './assets/You-female-tops--white-t-shirt.png';
 
-const { emotions: emotionsRyan, clothingData: clothingDataRyan } = generateEmotions({
+import You_male from './assets/You-male-body.png';
+import You_male_bottoms__shorts from './assets/You-male-bottoms--shorts.png'
+import You_male_bottoms__jeans from './assets/You-male-bottoms--jeans.png'
+import You_male_tops__pink_tshirt from './assets/You-male-tops--pink-t-shirt.png';
+import You_male_tops__white_tshirt from './assets/You-male-tops--white-t-shirt.png';
+
+const { emotions: emotionsYou, createActions: createActionsYou } = generateEmotions({
 	base: {
-		default: asset(Ryan_default),
-		zombie: asset(Ryan_zombie)
+		male: asset(You_male),
+		female: asset(You_female)
 	},
 	attributes: {
 		bottoms: {
 			shorts: {
-				zombie: asset(Ryan_zombie_bottoms__shorts),
-				default: asset(Ryan_default_bottoms__shorts)
+				female: asset(You_female_bottoms__shorts),
+				male: asset(You_male_bottoms__shorts)
 			},
 			jeans: {
-				zombie: asset(Ryan_zombie_bottoms__jeans),
-				default: asset(Ryan_default_bottoms__jeans)
+				female: asset(You_female_bottoms__jeans),
+				male: asset(You_male_bottoms__jeans)
 			}
 		},
 		tops: {
 			pink: {
-				default: asset(Ryan_default_tops__pink_tshirt),
-				zombie: asset(Ryan_zombie_tops__pink_tshirt)
+				male: asset(You_male_tops__pink_tshirt),
+				female: asset(You_female_tops__pink_tshirt)
 			},
 			white: {
-				default: asset(Ryan_default_tops__white_tshirt),
-				zombie: asset(Ryan_zombie_tops__white_tshirt)
+				male: asset(You_male_tops__white_tshirt),
+				female: asset(You_female_tops__white_tshirt)
 			}
 		}
 	}
 });
 
 const engine = novely({
-  ...,
+	...,
 	translation: {
 		en: {
 			internal: EN
 		}
 	},
 	characters: {
-		Ryan: {
+		You: {
 			name: {
-				en: 'Ryan Gosling',
+				en: 'You',
 			},
 			color: '#000000',
-			emotions: emotionsRyan
+			emotions: emotionsYou
 		},
 	},
 });
 
-const { showPicker: showPickerYou, showCharacter: showYou } = createPickerActions(engine.typeEssentials, clothingDataKyo, {
-	character: 'Ryan',
-	defaultBase: 'default',
+const dynamicYou = createActionsYou(engine, {
+	character: 'You',
+	defaultBase: 'male',
 	defaultAttributes: {
 		bottoms: 'jeans',
 		tops: 'white'
 	},
 	translation: {
 		en: {
-			tabs: {
+			title: {
 				base: 'Body',
 				attributes: {
 					bottoms: 'Bottoms',
@@ -90,8 +92,8 @@ const { showPicker: showPickerYou, showCharacter: showYou } = createPickerAction
 				}
 			},
 			base: {
-				default: 'Default',
-				zombie: 'Zombie'
+				male: 'Male',
+				female: 'Female'
 			},
 			attributes: {
 				bottoms: {
@@ -104,15 +106,32 @@ const { showPicker: showPickerYou, showCharacter: showYou } = createPickerAction
 				}
 			},
 			ui: {
-				tablist: 'Clothing Options',
 				variants: 'Options',
 				slidesControl: 'Slides Control',
 				prevSlide: 'Previous',
 				nextSlide: 'Next',
-				sumbit: 'Submit'
+				sumbit: 'Submit',
+				sumbit: 'Submit',
+				buy: 'Buy'
 			}
 		}
 	}
 });
+
+engine.script({
+	start: [
+		// Male or Female
+		dynamicYou.showBasePicker(),
+		// Jeans or Shorts
+		dynamicYou.showAttributePicker({ name: 'bottoms' }),
+		// Pink or White t-shirt
+		dynamicYou.showAttributePicker({ name: 'tops' }),
+		// Show the character
+		dynamicYou.showCharacter(),
+		// Admire the appearance :)
+		engine.action.say("You", "Mirror, Mirror on the Wall, Who’s the Fairest of Them All?"),
+		engine.action.end()
+	]
+})
 
 ```

--- a/packages/dynamic-character/README.md
+++ b/packages/dynamic-character/README.md
@@ -116,7 +116,3 @@ const { showPicker: showPickerYou, showCharacter: showYou } = createPickerAction
 });
 
 ```
-
-## Credits
-
-This project uses [Slidy](https://github.com/Valexr/Slidy) for drag-scrolling functionality.

--- a/packages/dynamic-character/build.js
+++ b/packages/dynamic-character/build.js
@@ -8,7 +8,7 @@ const dev = process.argv.at(2) === '--w';
 
 const context = await esbuild.context({
 	entryPoints: ['./src/index.ts', './src/index.css'],
-	external: ['solid-js', '@slidy/core'],
+	external: ['solid-js'],
 	charset: 'utf8',
 	jsx: 'preserve',
 	platform: 'browser',

--- a/packages/dynamic-character/build.js
+++ b/packages/dynamic-character/build.js
@@ -8,7 +8,7 @@ const dev = process.argv.at(2) === '--w';
 
 const context = await esbuild.context({
 	entryPoints: ['./src/index.ts', './src/index.css'],
-	external: ['solid-js'],
+	external: ['solid-js', 'p-limit'],
 	charset: 'utf8',
 	jsx: 'preserve',
 	platform: 'browser',

--- a/packages/dynamic-character/package.json
+++ b/packages/dynamic-character/package.json
@@ -20,6 +20,7 @@
 	},
 	"dependencies": {
 		"@novely/core": "workspace:*",
+		"p-limit": "^6.1.0",
 		"solid-js": "~1.9.3"
 	},
 	"peerDependencies": {

--- a/packages/dynamic-character/package.json
+++ b/packages/dynamic-character/package.json
@@ -20,7 +20,6 @@
 	},
 	"dependencies": {
 		"@novely/core": "workspace:*",
-		"@slidy/core": "^3.8.0",
 		"solid-js": "~1.9.3"
 	},
 	"peerDependencies": {

--- a/packages/dynamic-character/src/actions.ts
+++ b/packages/dynamic-character/src/actions.ts
@@ -1,0 +1,59 @@
+import type {
+	EngineInstance,
+	Attributes,
+	ClothingData,
+	AllOptions,
+	AllThis,
+	ShowPickerOptionsAttribute,
+	ShowPickerOptionsBase,
+	DefaultTypeEssentials,
+} from './types';
+import { showPicker } from './picker';
+import { showCharacter } from './show';
+
+const DEFAULT_SHOW_BASE_OPTIONS = {
+	type: 'base',
+	buy: async () => true,
+	isBought: () => true,
+} as const;
+
+const DEFAULT_SHOW_ATTRIBUTE_OPTIONS = {
+	type: 'attribute',
+	buy: async () => true,
+	isBought: () => true,
+} as const;
+
+const createActions = function (
+	this: ClothingData<string, Attributes>,
+	engine: EngineInstance,
+	options: AllOptions<DefaultTypeEssentials, string, Attributes>,
+) {
+	const that: AllThis = {
+		clothingData: this,
+		options,
+	};
+
+	return {
+		showBasePicker: (options: ShowPickerOptionsBase = {}) => {
+			const handler = showPicker.call(that, {
+				...DEFAULT_SHOW_BASE_OPTIONS,
+				...options,
+			});
+
+			return engine.action.custom(handler);
+		},
+		showAttributePicker: (options: ShowPickerOptionsAttribute<Attributes>) => {
+			const handler = showPicker.call(that, {
+				...DEFAULT_SHOW_ATTRIBUTE_OPTIONS,
+				...options,
+			});
+
+			return engine.action.custom(handler);
+		},
+		showCharacter: () => {
+			return engine.action.custom(showCharacter.call(that));
+		},
+	};
+};
+
+export { createActions };

--- a/packages/dynamic-character/src/components/Picker.tsx
+++ b/packages/dynamic-character/src/components/Picker.tsx
@@ -1,5 +1,5 @@
 import type { Component, Setter } from 'solid-js';
-import type { DynCharacterThis, EmotionObject } from '../types';
+import type { AllThis, EmotionObject } from '../types';
 import { createSignal, Show } from 'solid-js';
 import { Slider } from './Slider';
 import { once } from '../utils';
@@ -17,7 +17,7 @@ type PickerProps = {
 	pricing: number[];
 
 	translationGroup: Record<string, string>;
-	translation: DynCharacterThis['options']['translation'][string];
+	translation: AllThis['options']['translation'][string];
 
 	getInitialSlideIndex: (appearance: EmotionObject) => number;
 	onIndexChange: (appearance: EmotionObject, setAppearance: Setter<EmotionObject>, slide: number) => void;

--- a/packages/dynamic-character/src/components/Picker.tsx
+++ b/packages/dynamic-character/src/components/Picker.tsx
@@ -1,6 +1,6 @@
 import type { Component, Setter } from 'solid-js';
 import type { DynCharacterThis, EmotionObject } from '../types';
-import { createSignal, createEffect } from 'solid-js';
+import { createSignal, Show } from 'solid-js';
 import { Slider } from './Slider';
 
 type PickerProps = {
@@ -10,6 +10,8 @@ type PickerProps = {
 	initialEmotion: EmotionObject;
 
 	slides: string[];
+	pricing: number[];
+
 	translationGroup: Record<string, string>;
 	translation: DynCharacterThis['options']['translation'][string];
 
@@ -23,10 +25,6 @@ type PickerProps = {
 const Picker: Component<PickerProps> = (props) => {
 	const [expanded, setExpanded] = createSignal(props.initialExpanded);
 	const [appearance, setAppearance] = createSignal(props.initialEmotion);
-
-	createEffect(() => {
-		props.saveEmotion(appearance());
-	});
 
 	const initialSlideIndex = props.getInitialSlideIndex(appearance());
 
@@ -74,7 +72,7 @@ const Picker: Component<PickerProps> = (props) => {
 				translation={props.translation}
 				onIndexChange={(index) => props.onIndexChange(appearance(), setAppearance, index)}
 			>
-				{(variant) => (
+				{(variant, i) => (
 					<>
 						<p class="ndc-variant-name">{props.translationGroup[variant]}</p>
 
@@ -83,12 +81,23 @@ const Picker: Component<PickerProps> = (props) => {
 								type="button"
 								class="button"
 								onClick={() => {
-									if (true) {
+									// todo: make function to check if item is already bought
+									const free = !props.pricing[i()];
+
+									if (free) {
 										props.sumbit();
+										props.saveEmotion(appearance());
+									} else {
+										// todo: props.buy(variant).then((result) => if (result) /** then save and go next */)
+										console.log(`Trying to buy ${variant}`);
 									}
 								}}
 							>
-								{props.translation.ui.sumbit}
+								<Show when={props.pricing[i()]} fallback={props.translation.ui.sumbit}>
+									{props.translation.ui.buy}
+									&nbsp;
+									{props.pricing[i()]}
+								</Show>
 							</button>
 						</div>
 					</>

--- a/packages/dynamic-character/src/components/Picker.tsx
+++ b/packages/dynamic-character/src/components/Picker.tsx
@@ -80,26 +80,24 @@ const Picker: Component<PickerProps> = (props) => {
 				onIndexChange={(index) => props.onIndexChange(appearance(), setAppearance, index)}
 			>
 				{(variant, i) => {
-					const hasPrice = props.pricing[i()];
+					const price = props.pricing[i()];
 
 					const apply = once(() => {
 						props.sumbit();
 						props.saveEmotion(appearance());
 					});
 
-					const onClick = () =>
+					const onClick = () => {
 						limitClick(async () => {
-							if (!hasPrice) {
+							if (!price || props.isBought(variant)) {
+								return apply();
+							}
+
+							if (await props.buy(variant)) {
 								apply();
-							} else if (props.isBought(variant)) {
-								apply();
-							} else {
-								// todo: more advanced
-								if (await props.buy(variant)) {
-									apply();
-								}
 							}
 						});
+					};
 
 					return (
 						<>
@@ -107,11 +105,17 @@ const Picker: Component<PickerProps> = (props) => {
 
 							<div class="ndc-control-buttons">
 								<button type="button" class="button" onClick={onClick}>
-									<Show when={hasPrice && !props.isBought(variant)} fallback={props.translation.ui.sumbit}>
-										{props.translation.ui.buy}
-										&nbsp;
-										{props.pricing[i()]}
-									</Show>
+									<Show
+										when={price && !props.isBought(variant)}
+										children={
+											<>
+												{props.translation.ui.buy}
+												&nbsp;
+												{price}
+											</>
+										}
+										fallback={props.translation.ui.sumbit}
+									/>
 								</button>
 							</div>
 						</>

--- a/packages/dynamic-character/src/components/Picker.tsx
+++ b/packages/dynamic-character/src/components/Picker.tsx
@@ -1,0 +1,101 @@
+import type { Component, Setter } from 'solid-js';
+import type { DynCharacterThis, EmotionObject } from '../types';
+import { createSignal, createEffect } from 'solid-js';
+import { Slider } from './Slider';
+
+type PickerProps = {
+	title: string;
+
+	initialExpanded: boolean;
+	initialEmotion: EmotionObject;
+
+	slides: string[];
+	translationGroup: Record<string, string>;
+	translation: DynCharacterThis['options']['translation'][string];
+
+	getInitialSlideIndex: (appearance: EmotionObject) => number;
+	onIndexChange: (appearance: EmotionObject, setAppearance: Setter<EmotionObject>, slide: number) => void;
+	saveEmotion: (appearance: EmotionObject) => void;
+
+	sumbit: () => void;
+};
+
+const Picker: Component<PickerProps> = (props) => {
+	const [expanded, setExpanded] = createSignal(props.initialExpanded);
+	const [appearance, setAppearance] = createSignal(props.initialEmotion);
+
+	createEffect(() => {
+		props.saveEmotion(appearance());
+	});
+
+	const initialSlideIndex = props.getInitialSlideIndex(appearance());
+
+	return (
+		<div
+			classList={{
+				'ndc-picker-root': true,
+				'ndc-picker-root-collapsed': !expanded(),
+			}}
+		>
+			<button
+				type="button"
+				class="ndc-collapse-button"
+				onClick={() => {
+					setExpanded((value) => !value);
+				}}
+			>
+				<svg
+					data-icon
+					fill="#fefefe"
+					width="3rem"
+					height="3rem"
+					viewBox="0 0 256 256"
+					classList={{
+						'ndc-collapse-button-icon-collapsed': !expanded(),
+					}}
+				>
+					<path d="M213.66,101.66l-80,80a8,8,0,0,1-11.32,0l-80-80A8,8,0,0,1,53.66,90.34L128,164.69l74.34-74.35a8,8,0,0,1,11.32,11.32Z"></path>
+				</svg>
+			</button>
+
+			<div
+				classList={{
+					'ndc-heading': true,
+					'ndc-heading-picker-collapsed': !expanded(),
+				}}
+			>
+				{props.title}
+			</div>
+
+			<Slider
+				expanded={expanded()}
+				initialSlideIndex={initialSlideIndex}
+				slides={props.slides}
+				translation={props.translation}
+				onIndexChange={(index) => props.onIndexChange(appearance(), setAppearance, index)}
+			>
+				{(variant) => (
+					<>
+						<p class="ndc-variant-name">{props.translationGroup[variant]}</p>
+
+						<div class="ndc-control-buttons">
+							<button
+								type="button"
+								class="button"
+								onClick={() => {
+									if (true) {
+										props.sumbit();
+									}
+								}}
+							>
+								{props.translation.ui.sumbit}
+							</button>
+						</div>
+					</>
+				)}
+			</Slider>
+		</div>
+	);
+};
+
+export { Picker };

--- a/packages/dynamic-character/src/components/Slider.tsx
+++ b/packages/dynamic-character/src/components/Slider.tsx
@@ -1,12 +1,12 @@
 import type { Accessor, Component, JSX } from 'solid-js';
-import type { DynCharacterThis } from '../types';
+import type { AllThis } from '../types';
 import { createSignal, createEffect, untrack, createSelector, For } from 'solid-js';
 
 type SliderProps = {
 	initialSlideIndex: number;
 	slides: string[];
 	expanded: boolean;
-	translation: DynCharacterThis['options']['translation'][string];
+	translation: AllThis['options']['translation'][string];
 
 	children: (slide: string, i: Accessor<number>) => JSX.Element;
 	onIndexChange: (currentIndex: number) => void;

--- a/packages/dynamic-character/src/components/Slider.tsx
+++ b/packages/dynamic-character/src/components/Slider.tsx
@@ -1,4 +1,4 @@
-import type { Component, JSX } from 'solid-js';
+import type { Accessor, Component, JSX } from 'solid-js';
 import type { DynCharacterThis } from '../types';
 import { createSignal, createEffect, untrack, createSelector, For } from 'solid-js';
 
@@ -8,7 +8,7 @@ type SliderProps = {
 	expanded: boolean;
 	translation: DynCharacterThis['options']['translation'][string];
 
-	children: (slide: string) => JSX.Element;
+	children: (slide: string, i: Accessor<number>) => JSX.Element;
 	onIndexChange: (currentIndex: number) => void;
 };
 
@@ -89,7 +89,7 @@ const Slider: Component<SliderProps> = (props) => {
 									'ndc-slide-active': isSelected(i()),
 								}}
 							>
-								{props.children(variant)}
+								{props.children(variant, i)}
 							</div>
 						);
 					}}

--- a/packages/dynamic-character/src/components/Slider.tsx
+++ b/packages/dynamic-character/src/components/Slider.tsx
@@ -2,7 +2,7 @@ import type { Component, JSX } from 'solid-js';
 import type { DynCharacterThis } from '../types';
 import { createSignal, createEffect, untrack, createSelector, For } from 'solid-js';
 
-type Props = {
+type SliderProps = {
 	initialSlideIndex: number;
 	slides: string[];
 	expanded: boolean;
@@ -12,7 +12,7 @@ type Props = {
 	onIndexChange: (currentIndex: number) => void;
 };
 
-const Slider: Component<Props> = (props) => {
+const Slider: Component<SliderProps> = (props) => {
 	const [currentSlide, setCurrentSlide] = createSignal(props.initialSlideIndex);
 	const isSelected = createSelector(currentSlide);
 

--- a/packages/dynamic-character/src/components/Slider.tsx
+++ b/packages/dynamic-character/src/components/Slider.tsx
@@ -1,0 +1,102 @@
+import type { Component, JSX } from 'solid-js';
+import type { DynCharacterThis } from '../types';
+import { createSignal, createEffect, untrack, createSelector, For } from 'solid-js';
+
+type Props = {
+	initialSlideIndex: number;
+	slides: string[];
+	expanded: boolean;
+	translation: DynCharacterThis['options']['translation'][string];
+
+	children: (slide: string) => JSX.Element;
+	onIndexChange: (currentIndex: number) => void;
+};
+
+const Slider: Component<Props> = (props) => {
+	const [currentSlide, setCurrentSlide] = createSignal(props.initialSlideIndex);
+	const isSelected = createSelector(currentSlide);
+
+	createEffect(() => {
+		const currentIndex = currentSlide();
+
+		untrack(() => props.onIndexChange(currentIndex));
+	});
+
+	return (
+		<div
+			role="region"
+			aria-label={props.translation.ui.variants}
+			classList={{
+				'ndc-slider': true,
+				'ndc-slider-picker-collapsed': !props.expanded,
+			}}
+			onKeyDown={(event) => {
+				if (event.key === 'ArrowLeft') {
+					setCurrentSlide((value) => (value > 0 ? value - 1 : props.slides.length - 1));
+				} else if (event.key === 'ArrowRight') {
+					setCurrentSlide((value) => (value < props.slides.length - 1 ? value + 1 : 0));
+				}
+			}}
+		>
+			<div role="group" class="ndc-controls" aria-label={props.translation.ui.slidesControl}>
+				<button
+					type="button"
+					class="ndc-button-nav ndc-button-nav-prev"
+					aria-label={props.translation.ui.prevSlide}
+					onClick={() => {
+						setCurrentSlide((slide) => {
+							if (slide > 0) {
+								return slide - 1;
+							}
+
+							return props.slides.length - 1;
+						});
+					}}
+				>
+					<svg data-icon fill="currentColor" viewBox="0 0 256 256">
+						<path d="M165.66 202.34a8 8 0 0 1-11.32 11.32l-80-80a8 8 0 0 1 0-11.32l80-80a8 8 0 0 1 11.32 11.32L91.31 128Z" />
+					</svg>
+				</button>
+
+				<button
+					type="button"
+					class="ndc-button-nav ndc-button-nav-next"
+					aria-label={props.translation.ui.nextSlide}
+					onClick={() => {
+						setCurrentSlide((slide) => {
+							if (slide < props.slides.length - 1) {
+								return slide + 1;
+							}
+
+							return 0;
+						});
+					}}
+				>
+					<svg data-icon fill="currentColor" viewBox="0 0 256 256">
+						<path d="m181.66 133.66-80 80a8 8 0 0 1-11.32-11.32L164.69 128 90.34 53.66a8 8 0 0 1 11.32-11.32l80 80a8 8 0 0 1 0 11.32Z" />
+					</svg>
+				</button>
+			</div>
+
+			<div class="ndc-slides" aria-live="polite">
+				<For each={props.slides}>
+					{(variant, i) => {
+						return (
+							<div
+								role="group"
+								classList={{
+									'ndc-slide': true,
+									'ndc-slide-active': isSelected(i()),
+								}}
+							>
+								{props.children(variant)}
+							</div>
+						);
+					}}
+				</For>
+			</div>
+		</div>
+	);
+};
+
+export { Slider };

--- a/packages/dynamic-character/src/emotions.ts
+++ b/packages/dynamic-character/src/emotions.ts
@@ -1,6 +1,7 @@
 import type { NovelyAsset } from '@novely/core';
 import type { Attributes, EmotionsDefinition, EmotionsResult, Entries } from './types';
 import { toArray, getEntries, getKeys, permutation } from './utils';
+import { createActions } from './actions';
 
 const generateEmotions = <BaseKeys extends string, Attribs extends Attributes<BaseKeys>>({
 	base,
@@ -52,8 +53,8 @@ const generateEmotions = <BaseKeys extends string, Attribs extends Attributes<Ba
 
 	return {
 		emotions,
-		clothingData,
-	} as any;
+		createActions: createActions.bind(clothingData),
+	};
 };
 
 export { generateEmotions };

--- a/packages/dynamic-character/src/emotions.ts
+++ b/packages/dynamic-character/src/emotions.ts
@@ -5,6 +5,7 @@ import { toArray, getEntries, getKeys, permutation } from './utils';
 const generateEmotions = <BaseKeys extends string, Attribs extends Attributes<BaseKeys>>({
 	base,
 	attributes,
+	pricing,
 }: EmotionsDefinition<BaseKeys, Attribs>): EmotionsResult<BaseKeys, Attribs> => {
 	const emotions: Record<string, NovelyAsset[]> = {};
 
@@ -46,6 +47,7 @@ const generateEmotions = <BaseKeys extends string, Attribs extends Attributes<Ba
 	const clothingData = {
 		base: getKeys(base),
 		attributes: Object.fromEntries(getEntries(attributes).map(([name, value]) => [name, getKeys(value)])),
+		pricing,
 	};
 
 	return {

--- a/packages/dynamic-character/src/index.css
+++ b/packages/dynamic-character/src/index.css
@@ -50,42 +50,23 @@
 	display: none;
 }
 
-.ndc-tablist {
-	inline-size: 100%;
-	display: flex;
-	flex-flow: row nowrap;
+.ndc-heading {
+	inline-size: 40%;
 	gap: 0.5rem;
 	margin-top: -2rem;
-	padding: 0.25rem;
+	margin-inline: auto;
+	padding: 0.75rem;
 	background-color: #ffc7df;
 	border-radius: 0.875rem;
 	transition: opacity 150ms ease-in-out;
 	box-shadow: 0 0 0 0.15rem var(--appearance-picker-tablist-border-color, #ffa6cd), var(--novely-px)
 		var(--novely-px) 0.25rem var(--appearance-picker-box-shadow-color, #00000072);
+	text-align: center;
 }
 
-.ndc-tablist-picker-collapsed {
+.ndc-heading-picker-collapsed {
 	opacity: 0;
 	pointer-events: none;
-}
-
-.ndc-tab-button {
-	border: none;
-	box-shadow: 0 0 0 0.1rem #ffa6cd;
-	background-color: #ffe9f3;
-	padding: 0.55rem 0.85rem;
-	border-radius: 0.5rem;
-	cursor: pointer;
-	white-space: nowrap;
-	display: flex;
-	place-content: center;
-	align-items: center;
-	flex-shrink: 0;
-}
-
-.ndc-tab-button:hover {
-	background-color: #fff;
-	color: var(--novely-button-hover-color, #ffb7a2);
 }
 
 .ndc-slider {
@@ -188,7 +169,7 @@
 		transform: translateY(calc(100% - 1.2rem));
 	}
 
-	.ndc-tablist {
+	.ndc-heading {
 		box-shadow: 0 0 0 0.1rem var(--appearance-picker-tablist-border-color, #ffa6cd);
 	}
 
@@ -237,7 +218,7 @@
 		border-bottom-right-radius: 0;
 	}
 
-	.ndc-tablist-picker-collapsed {
+	.ndc-heading-picker-collapsed {
 		opacity: 0;
 		pointer-events: none;
 	}

--- a/packages/dynamic-character/src/index.ts
+++ b/packages/dynamic-character/src/index.ts
@@ -4,8 +4,8 @@ import type {
 	ClothingData,
 	DynCharacterOptions,
 	DynCharacterThis,
-	ShowPickerOptionsTypedAttribute,
-	ShowPickerOptionsTypedBase,
+	ShowPickerOptionsAttribute,
+	ShowPickerOptionsBase,
 } from './types';
 
 import { showPicker } from './picker';
@@ -38,7 +38,7 @@ const createDynamicCharacter = <
 	};
 
 	return {
-		showBasePicker: (options: ShowPickerOptionsTypedBase = {}) => {
+		showBasePicker: (options: ShowPickerOptionsBase = {}) => {
 			const handler = showPicker.call(that, {
 				...DEFAULT_SHOW_BASE_OPTIONS,
 				...options,
@@ -46,7 +46,7 @@ const createDynamicCharacter = <
 
 			return engine.action.custom(handler);
 		},
-		showAttributePicker: (options: ShowPickerOptionsTypedAttribute<Attribs>) => {
+		showAttributePicker: (options: ShowPickerOptionsAttribute<Attribs>) => {
 			const handler = showPicker.call(that, {
 				...DEFAULT_SHOW_ATTRIBUTE_OPTIONS,
 				...options,

--- a/packages/dynamic-character/src/index.ts
+++ b/packages/dynamic-character/src/index.ts
@@ -1,64 +1,10 @@
-import type {
-	EngineInstance,
+export type {
 	Attributes,
 	ClothingData,
-	DynCharacterOptions,
-	DynCharacterThis,
+	AllOptions,
+	EmotionObject,
+	EmotionsResult,
 	ShowPickerOptionsAttribute,
 	ShowPickerOptionsBase,
 } from './types';
-
-import { showPicker } from './picker';
-import { showCharacter } from './show';
-
-const DEFAULT_SHOW_BASE_OPTIONS = {
-	type: 'base',
-	buy: async () => true,
-	isBought: () => true,
-} as const;
-
-const DEFAULT_SHOW_ATTRIBUTE_OPTIONS = {
-	type: 'attribute',
-	buy: async () => true,
-	isBought: () => true,
-} as const;
-
-const createDynamicCharacter = <
-	Engine extends EngineInstance,
-	BaseKeys extends string,
-	Attribs extends Attributes<BaseKeys>,
->(
-	engine: Engine,
-	clothingData: ClothingData<BaseKeys, Attribs>,
-	options: DynCharacterOptions<NoInfer<Engine['typeEssentials']>, NoInfer<BaseKeys>, NoInfer<Attribs>>,
-) => {
-	const that: DynCharacterThis = {
-		clothingData,
-		options,
-	};
-
-	return {
-		showBasePicker: (options: ShowPickerOptionsBase = {}) => {
-			const handler = showPicker.call(that, {
-				...DEFAULT_SHOW_BASE_OPTIONS,
-				...options,
-			});
-
-			return engine.action.custom(handler);
-		},
-		showAttributePicker: (options: ShowPickerOptionsAttribute<Attribs>) => {
-			const handler = showPicker.call(that, {
-				...DEFAULT_SHOW_ATTRIBUTE_OPTIONS,
-				...options,
-			});
-
-			return engine.action.custom(handler);
-		},
-		showCharacter: () => {
-			return engine.action.custom(showCharacter.call(that));
-		},
-	};
-};
-
 export { generateEmotions } from './emotions';
-export { createDynamicCharacter };

--- a/packages/dynamic-character/src/picker.ts
+++ b/packages/dynamic-character/src/picker.ts
@@ -1,6 +1,6 @@
 import type { CustomHandler } from '@novely/core';
 import type { Setter } from 'solid-js';
-import type { DynCharacterThis, EmotionObject, ShowPickerOptions } from './types';
+import type { DynCharacterThis, EmotionObject, InternalShowPickerOptions } from './types';
 import { createComponent } from 'solid-js';
 import { render } from 'solid-js/web';
 import { getEmotionString, getSavedEmotion, once, saveEmotion } from './utils';
@@ -9,7 +9,7 @@ import { Picker } from './components/Picker';
 const CHARACTER_STYLE_PICKER = Symbol();
 const PRELOADED_EMOTIONS = new Set<string>();
 
-const showPicker = function (this: DynCharacterThis, options: ShowPickerOptions) {
+const showPicker = function (this: DynCharacterThis, options: InternalShowPickerOptions) {
 	const {
 		clothingData,
 		options: { character: characterId, defaultAttributes, defaultBase, translation: translations },

--- a/packages/dynamic-character/src/picker.ts
+++ b/packages/dynamic-character/src/picker.ts
@@ -1,6 +1,6 @@
 import type { CustomHandler } from '@novely/core';
 import type { Setter } from 'solid-js';
-import type { DynCharacterThis, EmotionObject, InternalShowPickerOptions } from './types';
+import type { AllThis, EmotionObject, InternalShowPickerOptions } from './types';
 import { createComponent } from 'solid-js';
 import { render } from 'solid-js/web';
 import { getEmotionString, getSavedEmotion, once, saveEmotion } from './utils';
@@ -9,7 +9,7 @@ import { Picker } from './components/Picker';
 const CHARACTER_STYLE_PICKER = Symbol();
 const PRELOADED_EMOTIONS = new Set<string>();
 
-const showPicker = function (this: DynCharacterThis, options: InternalShowPickerOptions) {
+const showPicker = function (this: AllThis, options: InternalShowPickerOptions) {
 	const {
 		clothingData,
 		options: { character: characterId, defaultAttributes, defaultBase, translation: translations },

--- a/packages/dynamic-character/src/picker.ts
+++ b/packages/dynamic-character/src/picker.ts
@@ -1,6 +1,6 @@
 import type { CustomHandler } from '@novely/core';
 import type { Setter } from 'solid-js';
-import type { DynCharacterThis, EmotionObject } from './types';
+import type { DynCharacterThis, EmotionObject, ShowPickerOptions } from './types';
 import { createComponent } from 'solid-js';
 import { render } from 'solid-js/web';
 import { getEmotionString, getSavedEmotion, once, saveEmotion } from './utils';
@@ -9,23 +9,7 @@ import { Picker } from './components/Picker';
 const CHARACTER_STYLE_PICKER = Symbol();
 const PRELOADED_EMOTIONS = new Set<string>();
 
-// todo: generic type in index.ts
-type ShowPickerOptions =
-	| {
-			type: 'base';
-	  }
-	| {
-			type: 'attribute';
-			name: string;
-	  };
-
-// todo: make it optional
-type ShowPickerBuyOptions = {
-	buy: (variant: string) => Promise<boolean>;
-	isBought: (variant: string) => boolean;
-};
-
-const showPicker = function (this: DynCharacterThis, options: ShowPickerOptions & ShowPickerBuyOptions) {
+const showPicker = function (this: DynCharacterThis, options: ShowPickerOptions) {
 	const {
 		clothingData,
 		options: { character: characterId, defaultAttributes, defaultBase, translation: translations },
@@ -56,7 +40,7 @@ const showPicker = function (this: DynCharacterThis, options: ShowPickerOptions 
 					title: translation.title.attributes[options.name],
 					slides: attributes[options.name],
 					translationGroup: translation.attributes[options.name],
-					pricing: slides.map((slide) => clothingData.pricing[options.name][slide]),
+					pricing: slides.map((slide) => (clothingData.pricing ? clothingData.pricing[options.name][slide] : 0)),
 
 					getInitialSlideIndex: (appearance: EmotionObject): number => {
 						return slides.indexOf(appearance.attributes[options.name]);

--- a/packages/dynamic-character/src/picker.ts
+++ b/packages/dynamic-character/src/picker.ts
@@ -33,6 +33,8 @@ const showPicker = function (this: AllThis, options: InternalShowPickerOptions) 
 		character.append();
 
 		const { title, slides, translationGroup, pricing, getInitialSlideIndex } = (() => {
+			const { pricing } = clothingData;
+
 			if (options.type === 'attribute') {
 				const slides = attributes[options.name];
 
@@ -40,7 +42,7 @@ const showPicker = function (this: AllThis, options: InternalShowPickerOptions) 
 					title: translation.title.attributes[options.name],
 					slides: attributes[options.name],
 					translationGroup: translation.attributes[options.name],
-					pricing: slides.map((slide) => (clothingData.pricing ? clothingData.pricing[options.name][slide] : 0)),
+					pricing: pricing ? slides.map((s) => pricing.attributes[options.name][s]) : Array(slides.length).fill(0),
 
 					getInitialSlideIndex: (appearance: EmotionObject): number => {
 						return slides.indexOf(appearance.attributes[options.name]);
@@ -52,7 +54,7 @@ const showPicker = function (this: AllThis, options: InternalShowPickerOptions) 
 				title: translation.title.base,
 				slides: base,
 				translationGroup: translation.base,
-				pricing: [],
+				pricing: pricing ? base.map((s) => pricing.base[s]) : Array(base.length).fill(0),
 
 				getInitialSlideIndex: (appearance: EmotionObject): number => {
 					return base.indexOf(appearance.base);

--- a/packages/dynamic-character/src/picker.ts
+++ b/packages/dynamic-character/src/picker.ts
@@ -1,6 +1,7 @@
 import type { CustomHandler } from '@novely/core';
 import type { Setter } from 'solid-js';
 import type { DynCharacterThis, EmotionObject } from './types';
+import { createComponent } from 'solid-js';
 import { render } from 'solid-js/web';
 import { getEmotionString, getSavedEmotion, once, saveEmotion } from './utils';
 import { Picker } from './components/Picker';
@@ -18,7 +19,13 @@ type ShowPickerOptions =
 			name: string;
 	  };
 
-const showPicker = function (this: DynCharacterThis, options: ShowPickerOptions) {
+// todo: make it optional
+type ShowPickerBuyOptions = {
+	buy: (variant: string) => Promise<boolean>;
+	isBought: (variant: string) => boolean;
+};
+
+const showPicker = function (this: DynCharacterThis, options: ShowPickerOptions & ShowPickerBuyOptions) {
 	const {
 		clothingData,
 		options: { character: characterId, defaultAttributes, defaultBase, translation: translations },
@@ -132,21 +139,22 @@ const showPicker = function (this: DynCharacterThis, options: ShowPickerOptions)
 		};
 
 		const cleanup = render(
-			() => (
-				<Picker
-					title={/* @once */ title}
-					initialExpanded={/* @once */ !flags.preview}
-					initialEmotion={/* @once */ initialEmotion}
-					slides={/* @once */ slides}
-					pricing={/* @once */ pricing}
-					translation={/* @once */ translation}
-					translationGroup={/* @once */ translationGroup}
-					getInitialSlideIndex={/* @once */ getInitialSlideIndex}
-					onIndexChange={/* @once */ onIndexChange}
-					saveEmotion={/* @once */ saveEmotionWrapper}
-					sumbit={/* @once */ resolve}
-				/>
-			),
+			() =>
+				createComponent(Picker, {
+					title,
+					initialExpanded: !flags.preview,
+					initialEmotion,
+					slides,
+					pricing,
+					translation,
+					translationGroup,
+					getInitialSlideIndex,
+					onIndexChange,
+					saveEmotion: saveEmotionWrapper,
+					sumbit: resolve,
+					buy: options.buy,
+					isBought: options.isBought,
+				}),
 			element,
 		);
 

--- a/packages/dynamic-character/src/picker.tsx
+++ b/packages/dynamic-character/src/picker.tsx
@@ -41,15 +41,18 @@ const showPicker = function (this: DynCharacterThis, options: ShowPickerOptions)
 		character.emotion(getEmotionString(initialEmotion), true);
 		character.append();
 
-		const { title, slides, translationGroup, getInitialSlideIndex } = (() => {
+		const { title, slides, translationGroup, pricing, getInitialSlideIndex } = (() => {
 			if (options.type === 'attribute') {
+				const slides = attributes[options.name];
+
 				return {
 					title: translation.title.attributes[options.name],
 					slides: attributes[options.name],
 					translationGroup: translation.attributes[options.name],
+					pricing: slides.map((slide) => clothingData.pricing[options.name][slide]),
 
-					getInitialSlideIndex(appearance: EmotionObject): number {
-						return this.slides.indexOf(appearance.attributes[options.name]);
+					getInitialSlideIndex: (appearance: EmotionObject): number => {
+						return slides.indexOf(appearance.attributes[options.name]);
 					},
 				};
 			}
@@ -58,8 +61,9 @@ const showPicker = function (this: DynCharacterThis, options: ShowPickerOptions)
 				title: translation.title.base,
 				slides: base,
 				translationGroup: translation.base,
+				pricing: [],
 
-				getInitialSlideIndex(appearance: EmotionObject): number {
+				getInitialSlideIndex: (appearance: EmotionObject): number => {
 					return base.indexOf(appearance.base);
 				},
 			};
@@ -134,6 +138,7 @@ const showPicker = function (this: DynCharacterThis, options: ShowPickerOptions)
 					initialExpanded={/* @once */ !flags.preview}
 					initialEmotion={/* @once */ initialEmotion}
 					slides={/* @once */ slides}
+					pricing={/* @once */ pricing}
 					translation={/* @once */ translation}
 					translationGroup={/* @once */ translationGroup}
 					getInitialSlideIndex={/* @once */ getInitialSlideIndex}

--- a/packages/dynamic-character/src/picker.tsx
+++ b/packages/dynamic-character/src/picker.tsx
@@ -1,9 +1,9 @@
 import type { CustomHandler } from '@novely/core';
+import type { Setter } from 'solid-js';
 import type { DynCharacterThis, EmotionObject } from './types';
 import { render } from 'solid-js/web';
-import { getEmotionString, getSavedEmotion, saveEmotion } from './utils';
-import { Slider } from './components/Slider';
-import { createEffect, createSignal, untrack } from 'solid-js';
+import { getEmotionString, getSavedEmotion, once, saveEmotion } from './utils';
+import { Picker } from './components/Picker';
 
 const CHARACTER_STYLE_PICKER = Symbol();
 const PRELOADED_EMOTIONS = new Set<string>();
@@ -41,150 +41,114 @@ const showPicker = function (this: DynCharacterThis, options: ShowPickerOptions)
 		character.emotion(getEmotionString(initialEmotion), true);
 		character.append();
 
-		const Picker = () => {
-			const [expanded, setExpanded] = createSignal(!flags.preview);
-			const [appearance, setAppearance] = createSignal<EmotionObject>(initialEmotion);
+		const { title, slides, translationGroup, getInitialSlideIndex } = (() => {
+			if (options.type === 'attribute') {
+				return {
+					title: translation.title.attributes[options.name],
+					slides: attributes[options.name],
+					translationGroup: translation.attributes[options.name],
 
-			createEffect(() => {
-				character.emotion(getEmotionString(appearance()), true);
-				saveEmotion(state, characterId, appearance());
-			});
+					getInitialSlideIndex(appearance: EmotionObject): number {
+						return this.slides.indexOf(appearance.attributes[options.name]);
+					},
+				};
+			}
 
-			const variants = options.type === 'attribute' ? attributes[options.name] : base;
-			const translationGroup =
-				options.type === 'attribute' ? translation.attributes[options.name] : translation.base;
+			return {
+				title: translation.title.base,
+				slides: base,
+				translationGroup: translation.base,
 
-			const initialSlideIndex = (() => {
-				const currentAppearance = untrack(appearance);
-
-				if (options.type === 'base') {
-					return base.indexOf(currentAppearance.base);
-				}
-
-				return variants.indexOf(currentAppearance.attributes[options.name]);
-			})();
-
-			const onIndexChange = (slide: number) => {
-				const currentAppearance = untrack(appearance);
-				const currentVariant = variants[slide];
-
-				if (options.type === 'base') {
-					const emotion = getEmotionString(
-						setAppearance({
-							base: currentVariant,
-							attributes: currentAppearance.attributes,
-						}),
-					);
-
-					character.emotion(emotion, true);
-					PRELOADED_EMOTIONS.add(emotion);
-				} else {
-					const emotion = getEmotionString(
-						setAppearance({
-							base: currentAppearance.base,
-							attributes: {
-								...currentAppearance.attributes,
-								[options.name]: currentVariant,
-							},
-						}),
-					);
-
-					character.emotion(emotion, true);
-					PRELOADED_EMOTIONS.add(emotion);
-				}
-
-				const nextIndex = slide < variants.length ? slide : 0;
-				const prevIndex = slide > 0 ? slide - 1 : variants.length - 1;
-
-				for (const index of [nextIndex, prevIndex]) {
-					const emotion =
-						options.type === 'base'
-							? getEmotionString({ base: variants[index], attributes: currentAppearance.attributes })
-							: getEmotionString({
-									base: currentAppearance.base,
-									attributes: { ...currentAppearance.attributes, [options.name]: variants[index] },
-								});
-
-					if (PRELOADED_EMOTIONS.has(emotion)) {
-						continue;
-					} else {
-						PRELOADED_EMOTIONS.add(emotion);
-					}
-
-					character.emotion(emotion, false);
-				}
+				getInitialSlideIndex(appearance: EmotionObject): number {
+					return base.indexOf(appearance.base);
+				},
 			};
+		})();
 
-			return (
-				<div
-					classList={{
-						'ndc-picker-root': true,
-						'ndc-picker-root-collapsed': !expanded(),
-					}}
-				>
-					<button
-						type="button"
-						class="ndc-collapse-button"
-						onClick={() => {
-							setExpanded((value) => !value);
-						}}
-					>
-						<svg
-							data-icon
-							fill="#fefefe"
-							width="3rem"
-							height="3rem"
-							viewBox="0 0 256 256"
-							classList={{
-								'ndc-collapse-button-icon-collapsed': !expanded(),
-							}}
-						>
-							<path d="M213.66,101.66l-80,80a8,8,0,0,1-11.32,0l-80-80A8,8,0,0,1,53.66,90.34L128,164.69l74.34-74.35a8,8,0,0,1,11.32,11.32Z"></path>
-						</svg>
-					</button>
+		const onIndexChange = (appearance: EmotionObject, setAppearance: Setter<EmotionObject>, slide: number) => {
+			/**
+			 * Update current
+			 */
+			const updated = slides[slide];
 
-					<div
-						classList={{
-							'ndc-heading': true,
-							'ndc-heading-picker-collapsed': !expanded(),
-						}}
-					>
-						{options.type === 'base' ? translation.title.base : translation.title.attributes[options.name]}
-					</div>
+			let emotion = '';
 
-					<Slider
-						expanded={expanded()}
-						initialSlideIndex={initialSlideIndex}
-						slides={variants}
-						translation={translation}
-						onIndexChange={onIndexChange}
-					>
-						{(variant) => (
-							<>
-								<p class="ndc-variant-name">{translationGroup[variant]}</p>
+			if (options.type === 'base') {
+				emotion = getEmotionString(
+					setAppearance({
+						base: updated,
+						attributes: appearance.attributes,
+					}),
+				);
+			} else {
+				emotion = getEmotionString(
+					setAppearance({
+						base: appearance.base,
+						attributes: {
+							...appearance.attributes,
+							[options.name]: updated,
+						},
+					}),
+				);
+			}
 
-								<div class="ndc-control-buttons">
-									<button
-										type="button"
-										class="button"
-										onClick={() => {
-											resolve();
-										}}
-									>
-										{translation.ui.sumbit}
-									</button>
-								</div>
-							</>
-						)}
-					</Slider>
-				</div>
-			);
+			character.emotion(emotion, true);
+			PRELOADED_EMOTIONS.add(emotion);
+
+			/**
+			 * Preload previous and next
+			 */
+			const nextIndex = slide < slides.length - 1 ? slide + 1 : 0;
+			const prevIndex = slide > 0 ? slide - 1 : slides.length - 1;
+
+			for (const index of [nextIndex, prevIndex]) {
+				let emotion = '';
+
+				if (options.type === 'base') {
+					emotion = getEmotionString({ base: slides[index], attributes: appearance.attributes });
+				} else {
+					emotion = getEmotionString({
+						base: appearance.base,
+						attributes: { ...appearance.attributes, [options.name]: slides[index] },
+					});
+				}
+
+				if (PRELOADED_EMOTIONS.has(emotion)) {
+					continue;
+				} else {
+					PRELOADED_EMOTIONS.add(emotion);
+				}
+
+				character.emotion(emotion, false);
+			}
 		};
 
-		const cleanup = render(() => <Picker />, element);
+		const saveEmotionWrapper = (appearance: EmotionObject) => {
+			saveEmotion(state, characterId, appearance);
+		};
 
-		clear(() => cleanup());
-		promise.then(() => cleanup());
+		const cleanup = render(
+			() => (
+				<Picker
+					title={/* @once */ title}
+					initialExpanded={/* @once */ !flags.preview}
+					initialEmotion={/* @once */ initialEmotion}
+					slides={/* @once */ slides}
+					translation={/* @once */ translation}
+					translationGroup={/* @once */ translationGroup}
+					getInitialSlideIndex={/* @once */ getInitialSlideIndex}
+					onIndexChange={/* @once */ onIndexChange}
+					saveEmotion={/* @once */ saveEmotionWrapper}
+					sumbit={/* @once */ resolve}
+				/>
+			),
+			element,
+		);
+
+		const cleanupOnce = once(cleanup);
+
+		clear(cleanupOnce);
+		promise.then(cleanupOnce);
 
 		return promise;
 	};

--- a/packages/dynamic-character/src/show.ts
+++ b/packages/dynamic-character/src/show.ts
@@ -1,10 +1,10 @@
 import type { CustomHandler } from '@novely/core';
-import type { DynCharacterThis } from './types';
+import type { AllThis } from './types';
 import { getEmotionString, getSavedEmotion } from './utils';
 
 const SHOW_CHARACTER = Symbol();
 
-const showCharacter = function (this: DynCharacterThis) {
+const showCharacter = function (this: AllThis) {
 	const handler: CustomHandler = ({ rendererContext, state }) => {
 		const emotion = getSavedEmotion(state, this.options.character, this.clothingData, {
 			base: this.options.defaultBase,

--- a/packages/dynamic-character/src/types.ts
+++ b/packages/dynamic-character/src/types.ts
@@ -162,22 +162,22 @@ type EmotionObject = {
 	attributes: Record<string, string>;
 };
 
-// todo: mark internal
-type ShowPickerBase = {
+type InternalShowPickerBase = {
 	type: 'base';
 };
 
-type ShowPickerAttribute = {
+type InternalShowPickerAttribute = {
 	type: 'attribute';
 	name: string;
 };
 
-type ShowPickerBuyOptions = {
+type InternalShowPickerBuyOptions = {
 	buy: (variant: string) => Promise<boolean>;
 	isBought: (variant: string) => boolean;
 };
 
-type ShowPickerOptions = (ShowPickerBase | ShowPickerAttribute) & ShowPickerBuyOptions;
+type InternalShowPickerOptions = (InternalShowPickerBase | InternalShowPickerAttribute) &
+	InternalShowPickerBuyOptions;
 
 type ShowPickerBuyFunctions = {
 	/**
@@ -194,15 +194,14 @@ type ShowPickerBuyFunctions = {
 	isBought?: (variant: string) => boolean;
 };
 
-// todo: remove typed
-type ShowPickerOptionsTypedAttribute<Attribs extends Attributes> = ShowPickerBuyFunctions & {
+type ShowPickerOptionsAttribute<Attribs extends Attributes> = ShowPickerBuyFunctions & {
 	/**
 	 * Name of the attribute
 	 */
 	name: keyof Attribs & string;
 };
 
-type ShowPickerOptionsTypedBase = ShowPickerBuyFunctions;
+type ShowPickerOptionsBase = ShowPickerBuyFunctions;
 
 type EngineInstance = {
 	action: Record<string, (...args: any[]) => ValidAction>;
@@ -219,8 +218,8 @@ export type {
 	DynCharacterOptions,
 	DynCharacterThis,
 	DefaultTypeEssentials,
-	ShowPickerOptions,
-	ShowPickerOptionsTypedAttribute,
-	ShowPickerOptionsTypedBase,
+	InternalShowPickerOptions,
+	ShowPickerOptionsAttribute,
+	ShowPickerOptionsBase,
 	EngineInstance,
 };

--- a/packages/dynamic-character/src/types.ts
+++ b/packages/dynamic-character/src/types.ts
@@ -8,6 +8,9 @@ type Attributes<BaseKeys extends string = string> = Record<
 type EmotionsDefinition<BaseKeys extends string, Attribs extends Attributes<BaseKeys>> = {
 	base: Record<BaseKeys, NovelyAsset | NovelyAsset[]>;
 	attributes: Attribs;
+	pricing: {
+		[Attribute in keyof Attribs]: Record<keyof Attribs[Attribute], number>;
+	};
 };
 
 /**
@@ -69,6 +72,9 @@ type ClothingData<BaseKeys extends string, Attribs extends Attributes<BaseKeys>>
 	base: BaseKeys[];
 	attributes: {
 		[Attribute in keyof Attribs]: (keyof Attribs[Attribute] & string)[];
+	};
+	pricing: {
+		[Attribute in keyof Attribs]: Record<keyof Attribs[Attribute], number>;
 	};
 
 	// Without this the `attributes` property is `Attributes` and not a narrow `Attribs`

--- a/packages/dynamic-character/src/types.ts
+++ b/packages/dynamic-character/src/types.ts
@@ -1,4 +1,4 @@
-import type { Character, Data, Lang, NovelyAsset, State, TypeEssentials } from '@novely/core';
+import type { Character, Data, Lang, NovelyAsset, State, TypeEssentials, ValidAction } from '@novely/core';
 
 type Attributes<BaseKeys extends string = string> = Record<
 	string,
@@ -8,7 +8,7 @@ type Attributes<BaseKeys extends string = string> = Record<
 type EmotionsDefinition<BaseKeys extends string, Attribs extends Attributes<BaseKeys>> = {
 	base: Record<BaseKeys, NovelyAsset | NovelyAsset[]>;
 	attributes: Attribs;
-	pricing: {
+	pricing?: {
 		[Attribute in keyof Attribs]: Record<keyof Attribs[Attribute], number>;
 	};
 };
@@ -73,7 +73,7 @@ type ClothingData<BaseKeys extends string, Attribs extends Attributes<BaseKeys>>
 	attributes: {
 		[Attribute in keyof Attribs]: (keyof Attribs[Attribute] & string)[];
 	};
-	pricing: {
+	pricing?: {
 		[Attribute in keyof Attribs]: Record<keyof Attribs[Attribute], number>;
 	};
 
@@ -162,6 +162,53 @@ type EmotionObject = {
 	attributes: Record<string, string>;
 };
 
+// todo: mark internal
+type ShowPickerBase = {
+	type: 'base';
+};
+
+type ShowPickerAttribute = {
+	type: 'attribute';
+	name: string;
+};
+
+type ShowPickerBuyOptions = {
+	buy: (variant: string) => Promise<boolean>;
+	isBought: (variant: string) => boolean;
+};
+
+type ShowPickerOptions = (ShowPickerBase | ShowPickerAttribute) & ShowPickerBuyOptions;
+
+type ShowPickerBuyFunctions = {
+	/**
+	 * Function to buy attribute variant
+	 * @param variant Attribute variant
+	 * @returns Boolean indicating is item bought or not
+	 */
+	buy?: (variant: string) => Promise<boolean>;
+	/**
+	 * Function to check is attribute variant is bought
+	 * @param variant Attribute variant
+	 * @returns Boolean indicating is item bought or not
+	 */
+	isBought?: (variant: string) => boolean;
+};
+
+// todo: remove typed
+type ShowPickerOptionsTypedAttribute<Attribs extends Attributes> = ShowPickerBuyFunctions & {
+	/**
+	 * Name of the attribute
+	 */
+	name: keyof Attribs & string;
+};
+
+type ShowPickerOptionsTypedBase = ShowPickerBuyFunctions;
+
+type EngineInstance = {
+	action: Record<string, (...args: any[]) => ValidAction>;
+	typeEssentials: DefaultTypeEssentials;
+};
+
 export type {
 	Entries,
 	EmotionsDefinition,
@@ -172,4 +219,8 @@ export type {
 	DynCharacterOptions,
 	DynCharacterThis,
 	DefaultTypeEssentials,
+	ShowPickerOptions,
+	ShowPickerOptionsTypedAttribute,
+	ShowPickerOptionsTypedBase,
+	EngineInstance,
 };

--- a/packages/dynamic-character/src/types.ts
+++ b/packages/dynamic-character/src/types.ts
@@ -76,21 +76,29 @@ type ClothingData<BaseKeys extends string, Attribs extends Attributes<BaseKeys>>
 	pricing?: {
 		[Attribute in keyof Attribs]: Record<keyof Attribs[Attribute], number>;
 	};
+};
 
-	// Without this the `attributes` property is `Attributes` and not a narrow `Attribs`
-	__attributes?: Attribs;
+type CreateActionsFN<BaseKeys extends string, Attribs extends Attributes<BaseKeys>> = {
+	<Engine extends EngineInstance>(
+		engine: Engine,
+		options: AllOptions<NoInfer<Engine['typeEssentials']>, NoInfer<BaseKeys>, NoInfer<Attribs>>,
+	): {
+		showBasePicker: (options?: ShowPickerOptionsBase) => ValidAction;
+		showAttributePicker: (options: ShowPickerOptionsAttribute<Attribs>) => ValidAction;
+		showCharacter: () => ValidAction;
+	};
 };
 
 type EmotionsResult<BaseKeys extends string, Attribs extends Attributes<BaseKeys>> = {
 	emotions: GeneratedEmotions<BaseKeys, Attribs>;
-	clothingData: Prettify<ClothingData<BaseKeys, Attribs>>;
+	createActions: CreateActionsFN<BaseKeys, Attribs>;
 };
 
 type Entries<T> = T extends Record<infer T, infer K> ? [T, K][] : never;
 
 type DefaultTypeEssentials = TypeEssentials<Lang, State, Data, Record<string, Character>>;
 
-type DynCharacterOptions<
+type AllOptions<
 	TE extends DefaultTypeEssentials,
 	BaseKeys extends string,
 	Attribs extends Attributes<BaseKeys>,
@@ -152,9 +160,9 @@ type DynCharacterOptions<
 	};
 };
 
-type DynCharacterThis = {
+type AllThis = {
 	clothingData: ClothingData<string, Attributes>;
-	options: DynCharacterOptions<DefaultTypeEssentials, string, Attributes>;
+	options: AllOptions<DefaultTypeEssentials, string, Attributes>;
 };
 
 type EmotionObject = {
@@ -215,8 +223,8 @@ export type {
 	Attributes,
 	ClothingData,
 	EmotionObject,
-	DynCharacterOptions,
-	DynCharacterThis,
+	AllOptions,
+	AllThis,
 	DefaultTypeEssentials,
 	InternalShowPickerOptions,
 	ShowPickerOptionsAttribute,

--- a/packages/dynamic-character/src/types.ts
+++ b/packages/dynamic-character/src/types.ts
@@ -104,10 +104,6 @@ type DynCharacterOptions<
 		[Attribute in keyof Attribs]: keyof Attribs[Attribute] & string;
 	};
 	/**
-	 * Attributes to exclude from picker
-	 */
-	excludeAttributes?: (keyof Attribs & string)[];
-	/**
 	 * Translation
 	 */
 	translation: {
@@ -127,16 +123,10 @@ type DynCharacterOptions<
 				[Base in BaseKeys]: string;
 			};
 			/**
-			 * Tabs translations
+			 * Title translations
 			 */
-			tabs: {
-				/**
-				 * Base tab translation
-				 */
+			title: {
 				base: string;
-				/**
-				 * Attribute translations
-				 */
 				attributes: {
 					[Attribute in keyof Attribs]: string;
 				};
@@ -145,12 +135,12 @@ type DynCharacterOptions<
 			 * Translation of UI components
 			 */
 			ui: {
-				tablist: string;
 				variants: string;
 				slidesControl: string;
 				prevSlide: string;
 				nextSlide: string;
 				sumbit: string;
+				buy: string;
 			};
 		};
 	};

--- a/packages/dynamic-character/src/types.ts
+++ b/packages/dynamic-character/src/types.ts
@@ -9,7 +9,10 @@ type EmotionsDefinition<BaseKeys extends string, Attribs extends Attributes<Base
 	base: Record<BaseKeys, NovelyAsset | NovelyAsset[]>;
 	attributes: Attribs;
 	pricing?: {
-		[Attribute in keyof Attribs]: Record<keyof Attribs[Attribute], number>;
+		base: Record<BaseKeys, number>;
+		attributes: {
+			[Attribute in keyof Attribs]: Record<keyof Attribs[Attribute], number>;
+		};
 	};
 };
 
@@ -74,7 +77,10 @@ type ClothingData<BaseKeys extends string, Attribs extends Attributes<BaseKeys>>
 		[Attribute in keyof Attribs]: (keyof Attribs[Attribute] & string)[];
 	};
 	pricing?: {
-		[Attribute in keyof Attribs]: Record<keyof Attribs[Attribute], number>;
+		base: Record<BaseKeys, number>;
+		attributes: {
+			[Attribute in keyof Attribs]: Record<keyof Attribs[Attribute], number>;
+		};
 	};
 };
 

--- a/packages/dynamic-character/src/utils.ts
+++ b/packages/dynamic-character/src/utils.ts
@@ -1,6 +1,17 @@
 import type { StateFunction, State } from '@novely/core';
 import type { EmotionObject, ClothingData, Attributes } from './types';
 
+const once = (fn: () => void) => {
+	let called = false;
+
+	return () => {
+		if (!called) {
+			called = true;
+			fn();
+		}
+	};
+};
+
 const getEntries = <T extends PropertyKey, K>(object: Record<T, K>): [T, K][] => {
 	return Object.entries(object) as any;
 };
@@ -86,4 +97,4 @@ const saveEmotion = (state: StateFunction<State>, character: string, emotion: Em
 	state({ [`$$emotion_${character}`]: emotion });
 };
 
-export { getEntries, getKeys, toArray, permutation, getEmotionString, saveEmotion, getSavedEmotion };
+export { once, getEntries, getKeys, toArray, permutation, getEmotionString, saveEmotion, getSavedEmotion };

--- a/packages/dynamic-character/tsconfig.json
+++ b/packages/dynamic-character/tsconfig.json
@@ -19,15 +19,7 @@
 		"jsx": "preserve",
 		"jsxImportSource": "solid-js",
 
-		"baseUrl": ".",
-		"paths": {
-			"$hooks": ["src/hooks"],
-			"$components": ["src/components"],
-			"$screens": ["src/screens"],
-			"$context": ["src/context"],
-			"$utils": ["src/utils"],
-			"$actions": ["src/actions"]
-		}
+		"baseUrl": "."
 	},
 	"include": ["src"]
 }

--- a/packages/solid-renderer/package.json
+++ b/packages/solid-renderer/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@novely/solid-renderer",
-	"version": "0.46.0",
+	"version": "0.47.0-experemental.0",
 	"type": "module",
 	"publishConfig": {
 		"access": "public"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -128,6 +128,9 @@ importers:
       '@novely/core':
         specifier: workspace:*
         version: link:../core
+      p-limit:
+        specifier: ^6.1.0
+        version: 6.1.0
       solid-js:
         specifier: ~1.9.3
         version: 1.9.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -79,11 +79,11 @@ importers:
   packages/create-novely/template-solid-js:
     dependencies:
       '@novely/core':
-        specifier: ~0.46.0
-        version: 0.46.0(klona@2.0.6)
+        specifier: ~0.48.0
+        version: 0.48.0(klona@2.0.6)
       '@novely/solid-renderer':
-        specifier: ~0.42.0
-        version: 0.42.0(@novely/core@0.46.0(klona@2.0.6))(klona@2.0.6)(postcss@8.4.49)(solid-js@1.9.1)
+        specifier: ~0.46.0
+        version: 0.46.0(@novely/core@0.48.0(klona@2.0.6))(klona@2.0.6)(postcss@8.4.49)(solid-js@1.9.1)
       modern-normalize:
         specifier: ~3.0.1
         version: 3.0.1
@@ -93,7 +93,7 @@ importers:
     devDependencies:
       '@novely/vite-plugin-novely':
         specifier: ~0.6.1
-        version: 0.6.1(@novely/core@0.46.0(klona@2.0.6))(vite@6.0.1(@types/node@20.3.1)(lightningcss@1.28.1))
+        version: 0.6.1(@novely/core@0.48.0(klona@2.0.6))(vite@6.0.1(@types/node@20.3.1)(lightningcss@1.28.1))
       vite:
         specifier: ~6.0.1
         version: 6.0.1(@types/node@20.3.1)(lightningcss@1.28.1)
@@ -101,11 +101,11 @@ importers:
   packages/create-novely/template-solid-js-yagames:
     dependencies:
       '@novely/core':
-        specifier: ~0.46.0
-        version: 0.46.0(klona@2.0.6)
+        specifier: ~0.48.0
+        version: 0.48.0(klona@2.0.6)
       '@novely/solid-renderer':
-        specifier: ~0.42.0
-        version: 0.42.0(@novely/core@0.46.0(klona@2.0.6))(klona@2.0.6)(postcss@8.4.49)(solid-js@1.9.1)
+        specifier: ~0.46.0
+        version: 0.46.0(@novely/core@0.48.0(klona@2.0.6))(klona@2.0.6)(postcss@8.4.49)(solid-js@1.9.1)
       modern-normalize:
         specifier: ~3.0.1
         version: 3.0.1
@@ -115,7 +115,7 @@ importers:
     devDependencies:
       '@novely/vite-plugin-novely':
         specifier: ~0.6.1
-        version: 0.6.1(@novely/core@0.46.0(klona@2.0.6))(vite@6.0.1(@types/node@20.3.1)(lightningcss@1.28.1))
+        version: 0.6.1(@novely/core@0.48.0(klona@2.0.6))(vite@6.0.1(@types/node@20.3.1)(lightningcss@1.28.1))
       '@vitejs/plugin-basic-ssl':
         specifier: ^1.2.0
         version: 1.2.0(vite@6.0.1(@types/node@20.3.1)(lightningcss@1.28.1))
@@ -128,9 +128,6 @@ importers:
       '@novely/core':
         specifier: workspace:*
         version: link:../core
-      '@slidy/core':
-        specifier: ^3.8.0
-        version: 3.8.0
       solid-js:
         specifier: ~1.9.3
         version: 1.9.3
@@ -923,24 +920,24 @@ packages:
     peerDependencies:
       klona: ^2.0.6
 
-  '@novely/core@0.45.2':
-    resolution: {integrity: sha512-PgrzhE7qBMeIVAjbKGilshct7D3AwVd51W55FKI4ZFOEeV4xpXdaOFqaY1LcDn85cXu+Zi6nAbYWiCtTo91ZpQ==}
+  '@novely/core@0.47.2':
+    resolution: {integrity: sha512-kmUkX6RYWuKNwNYuvfW6plvsBFXwqgEmhsJa55EzvmTmmsVO9PrZogiRyeKm3Kdms1HmU/+LP5TX6zHrrWov/w==}
     peerDependencies:
       klona: ^2.0.6
 
-  '@novely/core@0.46.0':
-    resolution: {integrity: sha512-vW3WhX3WAOxYA/yb/jaG5G7OrwdPk+hWvK912OBpy17Z4pHwhH3R+iYD275Hsh0fcCByuovKlHNRz50YVuUwsA==}
+  '@novely/core@0.48.0':
+    resolution: {integrity: sha512-OCoqEMfqZJblTGn8HoSHOkhgcYTFxXwEL9suMhou8PiUPPqKp+ePbG4gXypSj+MQ7epuP60KzeFWTnr3GrkEyQ==}
     peerDependencies:
       klona: ^2.0.6
 
   '@novely/parser@0.7.0':
     resolution: {integrity: sha512-pX4E1oNluqUn27sfkFi7k1Q0JRx9+PfmTlSiKTF6ix1sjeQv1aey5mIz9CV5xytRrz6QzO2SU8qNGFnyZwduWQ==}
 
-  '@novely/renderer-toolkit@0.12.0':
-    resolution: {integrity: sha512-XraodWodxOAgfd1hFVplxIXxA4vsw6FGP2GfJ1Y/0wsa89lFOPlr6GWZfrHAjU/xhCg4qywJaTFnVdyflhrjDA==}
+  '@novely/renderer-toolkit@0.12.1':
+    resolution: {integrity: sha512-kNEizqP4i+HOBJFJKigKDWLgUjKG0Mkj1JgEMfVcniDNssRcZRQZI9hsojkiyMBlm4/+7PQAKJamfQSHaOT0vw==}
 
-  '@novely/solid-renderer@0.42.0':
-    resolution: {integrity: sha512-OgHWIdYwh3nWFi+fzmZaWQfQKG0NT+4+W+sVuEfwn8+GrJGgzAoX0jRffi9IikSakGZ5pCauNDm+O2TlXSql/g==}
+  '@novely/solid-renderer@0.46.0':
+    resolution: {integrity: sha512-Mg7ffbnLy8ZgBcW2r0AImp0E4cbjda89k2mUa69L5g5EVSOxkO3m9x2PsCD+wUtD80M8/occ3d5/FryBkgymXg==}
     peerDependencies:
       '@novely/core': '*'
       solid-js: '*'
@@ -1050,9 +1047,6 @@ packages:
     resolution: {integrity: sha512-3j4jx1TppORdTAoBJRd+/wJRGCPC0ETWkXOecJ6PPZLj6SptXkrXcNqdj0oclbKML6FkQltdz7bBA3rUSirZug==}
     cpu: [x64]
     os: [win32]
-
-  '@slidy/core@3.8.0':
-    resolution: {integrity: sha512-rtPI5ZrlueiS8wTFLVefPPFnv4VF667VUA0o28y7H2hrRn3f58EdOjefHrvYjepcUCJ2mF3jpsx/FWOEUNj/7w==}
 
   '@solid-primitives/destructure@0.1.17':
     resolution: {integrity: sha512-MTjEIIeiw36Png0tze70XnhQ79IbkreX8v0qpjJ77+CLT5MkVQtFoiNHGkZPyw7UtkZQE08qvV6KAJw8s9dCwg==}
@@ -2437,7 +2431,7 @@ snapshots:
       klona: 2.0.6
       p-limit: 6.1.0
 
-  '@novely/core@0.45.2(klona@2.0.6)':
+  '@novely/core@0.47.2(klona@2.0.6)':
     dependencies:
       dequal: 2.0.3
       es-toolkit: 1.23.0
@@ -2445,7 +2439,7 @@ snapshots:
       klona: 2.0.6
       p-limit: 6.1.0
 
-  '@novely/core@0.46.0(klona@2.0.6)':
+  '@novely/core@0.48.0(klona@2.0.6)':
     dependencies:
       dequal: 2.0.3
       es-toolkit: 1.23.0
@@ -2455,9 +2449,9 @@ snapshots:
 
   '@novely/parser@0.7.0': {}
 
-  '@novely/renderer-toolkit@0.12.0(klona@2.0.6)(postcss@8.4.49)':
+  '@novely/renderer-toolkit@0.12.1(klona@2.0.6)(postcss@8.4.49)':
     dependencies:
-      '@novely/core': 0.45.2(klona@2.0.6)
+      '@novely/core': 0.47.2(klona@2.0.6)
       dequal: 2.0.3
       esm-env: 1.0.0
       nanostores: 0.11.3
@@ -2473,10 +2467,10 @@ snapshots:
       - tsx
       - yaml
 
-  '@novely/solid-renderer@0.42.0(@novely/core@0.46.0(klona@2.0.6))(klona@2.0.6)(postcss@8.4.49)(solid-js@1.9.1)':
+  '@novely/solid-renderer@0.46.0(@novely/core@0.48.0(klona@2.0.6))(klona@2.0.6)(postcss@8.4.49)(solid-js@1.9.1)':
     dependencies:
-      '@novely/core': 0.46.0(klona@2.0.6)
-      '@novely/renderer-toolkit': 0.12.0(klona@2.0.6)(postcss@8.4.49)
+      '@novely/core': 0.48.0(klona@2.0.6)
+      '@novely/renderer-toolkit': 0.12.1(klona@2.0.6)(postcss@8.4.49)
       '@novely/typewriter': 0.5.1
       '@solid-primitives/destructure': 0.1.17(solid-js@1.9.1)
       clsx: 2.1.1
@@ -2495,9 +2489,9 @@ snapshots:
 
   '@novely/typewriter@0.5.1': {}
 
-  '@novely/vite-plugin-novely@0.6.1(@novely/core@0.46.0(klona@2.0.6))(vite@6.0.1(@types/node@20.3.1)(lightningcss@1.28.1))':
+  '@novely/vite-plugin-novely@0.6.1(@novely/core@0.48.0(klona@2.0.6))(vite@6.0.1(@types/node@20.3.1)(lightningcss@1.28.1))':
     dependencies:
-      '@novely/core': 0.46.0(klona@2.0.6)
+      '@novely/core': 0.48.0(klona@2.0.6)
       '@novely/parser': 0.7.0
       vite: 6.0.1(@types/node@20.3.1)(lightningcss@1.28.1)
 
@@ -2559,8 +2553,6 @@ snapshots:
 
   '@rollup/rollup-win32-x64-msvc@4.27.4':
     optional: true
-
-  '@slidy/core@3.8.0': {}
 
   '@solid-primitives/destructure@0.1.17(solid-js@1.9.1)':
     dependencies:


### PR DESCRIPTION
Now it supports buying of character bases and clothing attributes. Picker is now splitted, base and attributes are selected separately, including each attribute being selected separately. It's the same as how it's done in many other games. This way it's easier for player to buy items.


Ideally, it would be good, from the point of view of technical implementation, not to create each permutation for each outfit, but at the moment the engine does not allow dynamically rendering emotions. This PR doesn't touch on this part, but one day it will need to be addressed.